### PR TITLE
Without this there are some css files in themes/classic/css like aui.css, base.css, dockbar.css, navigation.css and portlet.css that are completely empty (0 bytes) while the rest are OK.

### DIFF
--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -672,9 +672,19 @@
 					</then>
 				</if>
 
-				<sync todir="@{module.name}">
+				<sync todir="@{module.name}" overwrite="true">
 					<fileset dir="docroot/html/themes/_unstyled" excludes="templates/init.ftl,templates/init.vm" />
+					<preserveintarget>
+						<include name="**/*" />
+					</preserveintarget>
+				</sync>
+				<sync todir="@{module.name}" overwrite="true">
 					<fileset dir="docroot/html/themes/_styled" />
+					<preserveintarget>
+						<include name="**/*" />
+					</preserveintarget>
+				</sync>
+				<sync todir="@{module.name}" overwrite="true">
 					<fileset dir="@{module.name}/_diffs" />
 					<preserveintarget>
 						<include name="**/*" />
@@ -1150,6 +1160,7 @@ Please set the property "jdk.6.home" in build.properties.
 				<equals arg1="${app.server.type}" arg2="tomcat" />
 			</or>
 			<then>
+				<echo message="${app.server.portal.dir}" />
 				<copy todir="${app.server.portal.dir}" preservelastmodified="true">
 					<fileset dir="docroot">
 						<include name="**/*.css" />


### PR DESCRIPTION
Hey Chas,

During last 2 was I had lot of issues with css in portal and today I found out that it may be caused by changes of commit "LPS-52169 Organize portal-web dependencies more efficiently" where <copy> was replaced with <sync>.

However, it's working properly to other people, so I'm not totally sure about what is the root cause of the failure. However, with the code that I'm sending it works properly for me. I guess that it could be related to the <sync> but I'm not sure why it's failing. 

I set the verbose property and the log says that it's doing it right: basically moving from _unstyled -> classic and from _styled -> classic which is right, but for some reason the final result in my case doesn't contain the right css.

Can you check it out to see why it may be failing? If you need any more info please let me know, because I think that what is happening to me could happen to more people

Thanks!
Sergio
