### PR TITLE
LPS-85676 portal-ext.properies files are not read during startup after using 'ant snapshot-bundle'

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1135,7 +1135,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 			tofile="${liferay.home}"
 		/>
 
-		<deploy-properties deploy.properties.dest="${app.server.parent.dir}/tomcat/WEB-INF/classes" />
+		<deploy-properties deploy.properties.dest="${app.server.parent.dir}/tomcat/webapps/ROOT/WEB-INF/classes" />
 
 		<if>
 			<os family="unix" />


### PR DESCRIPTION
This is an update for [LPS-85676](https://issues.liferay.com/browse/LPS-85676).